### PR TITLE
feat: Redirect to IDIR login

### DIFF
--- a/centre-web/src/utils/config.ts
+++ b/centre-web/src/utils/config.ts
@@ -44,4 +44,5 @@ export const OidcConfig = {
   post_logout_redirect_uri: `${APP_URL}/`,
   scope: "openid profile email",
   revokeTokensOnSignout: true,
+  extraQueryParams: { kc_idp_hint: "idir" },
 };


### PR DESCRIPTION
Adds `kc_idp_hint` to the OIDC configuration to bypass the Keycloak login page and redirect directly to the IDIR login.